### PR TITLE
fix: correct typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # nase.gg
-This reposity is the underlying code for the NASE Discord and FFXIV NA raiding community. It is built using [Docusaurus](https://docusaurus.io/), a modern static website generator. Contirubtions are welcome! If you would like to contribute to the site, please read the section below.
+This reposity is the underlying code for the NASE Discord and FFXIV NA raiding community. It is built using [Docusaurus](https://docusaurus.io/), a modern static website generator. Contributions are welcome! If you would like to contribute to the site, please read the section below.
 
 # How to contribute
 
 This guide will walk you through the steps to fork the repository, make changes, and submit a pull request (PR) to contribute.
 
-If you already know how to ccontribute to a GitHub repository, feel free to skip this.
+If you already know how to contribute to a GitHub repository, feel free to skip this.
 
 ## Table of Contents
 


### PR DESCRIPTION
Corrects a few small typos in the readme.

Personally I'd also suggest you consider wrapping lines in markdown files at an agreed upon line length. Easy to enforce with tooling, a bit more developer friendly without assuming that every contributor is using a particular editor.