### PR TITLE
fix: Fix spelling error for Learning Opportunities link in footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -144,7 +144,7 @@ const config = {
                 to: '/about',
               },
               {
-                label: 'Learning Oppurtunities',
+                label: 'Learning Opportunities',
                 to: '/learning',
               },
             ],


### PR DESCRIPTION
As title, noticed a misspelling while I was browsing the site earlier